### PR TITLE
Add logging for troubleshooting

### DIFF
--- a/codice/__init__.py
+++ b/codice/__init__.py
@@ -4,6 +4,9 @@
 #from feature_manager import FeatureManager
 
 import argparse
+from .logging_utils import setup_logging
+
+setup_logging()
 
 
 

--- a/codice/ceinstance/instance_sampler.py
+++ b/codice/ceinstance/instance_sampler.py
@@ -7,6 +7,8 @@ import json
 import inspect
 import logging
 
+logger = logging.getLogger(__name__)
+
 class CEInstanceSampler(object):
     def __init__(self, config, transformers, instance_factory, normalization=True, custom_rules=None):
         self.config = config
@@ -39,12 +41,12 @@ class CEInstanceSampler(object):
 
         for feature_name, constraint in all_constraints.items():
             if constraint['type'] == 'dependency':
-                print(f"Dependency Type: {constraint['dependencyType']}")
-                print(f"Root: {feature_name}")
+                logger.debug("Dependency Type: %s", constraint['dependencyType'])
+                logger.debug("Root: %s", feature_name)
                 child_feature = constraint['child']
                 child_range = self._get_feature_range(child_feature)
-                print(f"Child: {child_feature}")
-                print(f"Child Range: {child_range}")
+                logger.debug("Child: %s", child_feature)
+                logger.debug("Child Range: %s", child_range)
                 if constraint['dependencyType'] == 'causal':
                     try:
                         child_sampler = self.feature_samplers[child_feature] # just use the sampler that was already created
@@ -53,7 +55,7 @@ class CEInstanceSampler(object):
                 elif constraint['dependencyType'] == 'monotonic_dependency':
                     child_sampler = MonotonicSampler(child_feature, child_range, "increasing")
                 elif constraint['dependencyType'] == 'rule':
-                    print(f"Rule: {constraint['rule']}")
+                    logger.debug("Rule: %s", constraint['rule'])
                     try:
                         rule_function = self.custom_rules[constraint['rule']]
                     except KeyError:
@@ -77,8 +79,8 @@ class CEInstanceSampler(object):
 
     def _create_default_samplers(self, feature_name, is_dependency=False):
         feature_range = self._get_feature_range(feature_name)
-        print(f"Feature: {feature_name}")
-        print(f"Range: {feature_range}")
+        logger.debug("Feature: %s", feature_name)
+        logger.debug("Range: %s", feature_range)
 
         if inspect.isclass(self.instance_factory.instance_schema[feature_name]):
             if issubclass(self.instance_factory.instance_schema[feature_name], NumCEFeature):
@@ -102,12 +104,12 @@ class CEInstanceSampler(object):
     def _create_sampler_from_constraint(self, feature_name, constraint):
         feature_range = self._get_feature_range(feature_name)
 
-        print(f"Feature: {feature_name}")
-        print(f"Range: {feature_range}")
-        print(f"Constraint Type: {constraint['type']}")
+        logger.debug("Feature: %s", feature_name)
+        logger.debug("Range: %s", feature_range)
+        logger.debug("Constraint Type: %s", constraint['type'])
 
         if constraint['type'] == 'monotonic':
-            print(f"Direction: {constraint['direction']}")
+            logger.debug("Direction: %s", constraint['direction'])
             sampler = MonotonicSampler(feature_name, feature_range, constraint['direction'])
         elif constraint['type'] == 'immutable':
             sampler = ImmutableSampler(feature_name, feature_range)

--- a/codice/cemodels/gp_model.py
+++ b/codice/cemodels/gp_model.py
@@ -1,6 +1,9 @@
+import logging
 from .model_interface import ModelInterface
 import json
 from codice.ceinstance import CEInstance
+
+logger = logging.getLogger(__name__)
 
 class GeneticProgrammingModel(ModelInterface):
     def __init__(self, model_config):
@@ -17,7 +20,7 @@ class GeneticProgrammingModel(ModelInterface):
                 model_number = model_config.get('gp_params').get('model_number')
                 # Depending if user enumerates models from 1 or 0
                 self.model = self.models[model_number-1]
-                print("First model is ", self.model)
+                logger.debug("First model is %s", self.model)
         else: self.model = self.train(model_config)
 
     def train(self, model_config):
@@ -73,7 +76,7 @@ class GeneticProgrammingModel(ModelInterface):
         if gp_model is None:
             raise Exception("Model {} not found in {}".format(self.model_name, filepath))
         parsed_expressions = self.parse_expressions(gp_model)
-        print("Parsed expressions are ", parsed_expressions)
+        logger.debug("Parsed expressions are %s", parsed_expressions)
         return parsed_expressions
     
     def parse_expressions(self, expressions):

--- a/codice/cemodels/sklearn_model.py
+++ b/codice/cemodels/sklearn_model.py
@@ -1,9 +1,12 @@
+import logging
 from .model_interface import ModelInterface
 from codice.ceinstance import CEInstance
 from joblib import load
 import pickle
 import numpy as np
 import warnings
+
+logger = logging.getLogger(__name__)
 
 class SklearnModel(ModelInterface):
     def __init__(self, model_config):
@@ -42,7 +45,7 @@ class SklearnModel(ModelInterface):
         """
         # Suppress specific warning
         warnings.filterwarnings(action='ignore', category=UserWarning)
-        print(x.to_numpy_array())
+        logger.debug(x.to_numpy_array())
         return self.predict(x.to_numpy_array().reshape(1, -1))[0]
         
     def predict_proba_instance(self, x: CEInstance):
@@ -50,7 +53,7 @@ class SklearnModel(ModelInterface):
         Predict instance
         """
         warnings.filterwarnings(action='ignore', category=UserWarning)
-        print(x.to_numpy_array())
+        logger.debug(x.to_numpy_array())
         return self.predict_proba(x.to_numpy_array().reshape(1, -1))[0]
 
     def evaluate(self, X, y):
@@ -65,7 +68,7 @@ class SklearnModel(ModelInterface):
                 model = load(f)
                 return model
             except Exception as e:
-                print(f"Error loading model: {e}")
+                logger.error("Error loading model: %s", e)
 
     def get_base_estimator_input_shape(self):
         """
@@ -102,10 +105,10 @@ class SklearnModel(ModelInterface):
 
     def sanity_check(self):
         if self.config["state"] == "pretrained":
-            print("Sanity check for model")
+            logger.info("Sanity check for model")
             input_shape = self.get_base_estimator_input_shape()
-            print("Model input shape is ", input_shape)
+            logger.debug("Model input shape is %s", input_shape)
             fake_input = np.random.rand(input_shape)
             fake_input = fake_input.reshape(1, -1)
             self.predict(fake_input)
-            print("Sanity check prediciton ", self.predict(fake_input))
+            logger.debug("Sanity check prediction %s", self.predict(fake_input))

--- a/codice/cemodels/sklearn_pipeline.py
+++ b/codice/cemodels/sklearn_pipeline.py
@@ -1,9 +1,12 @@
+import logging
 from sklearn.pipeline import Pipeline
 from .model_interface import ModelInterface
 from codice.ceinstance import CEInstance
 from joblib import load
 import numpy as np
 import warnings
+
+logger = logging.getLogger(__name__)
 
 class SklearnPipeline(ModelInterface):
     def __init__(self, model_config):
@@ -58,7 +61,7 @@ class SklearnPipeline(ModelInterface):
                 model = load(f)
                 return model
             except Exception as e:
-                print(f"Error loading model: {e}")
+                logger.error("Error loading model: %s", e)
 
     def get_base_estimator_input_shape(self):
         """
@@ -82,12 +85,12 @@ class SklearnPipeline(ModelInterface):
 
     def sanity_check(self):
         if self.model_state == "pretrained":
-            print("Sanity check for pipeline model")
+            logger.info("Sanity check for pipeline model")
             try:
                 input_shape = self.get_base_estimator_input_shape()
-                print("Model input shape is ", input_shape)
+                logger.debug("Model input shape is %s", input_shape)
                 fake_input = np.random.rand(1, input_shape)  # Adjusted for a single sample
                 pred = self.predict(fake_input)
-                print("Sanity check prediction: ", pred)
+                logger.debug("Sanity check prediction: %s", pred)
             except ValueError as e:
-                print("Sanity check failed:", e)
+                logger.error("Sanity check failed: %s", e)

--- a/codice/cemodels/tensorflow_model.py
+++ b/codice/cemodels/tensorflow_model.py
@@ -1,8 +1,11 @@
+import logging
 from .model_interface import ModelInterface
 from codice.ceinstance import CEInstance
 import tensorflow as tf
 import numpy as np
 import warnings
+
+logger = logging.getLogger(__name__)
 
 class TensorflowModel(ModelInterface):
     def __init__(self, model_config, model, preprocessor=None):
@@ -77,7 +80,7 @@ class TensorflowModel(ModelInterface):
             model = tf.keras.models.load_model(filepath)
             return model
         except Exception as e:
-            print(f"Error loading model: {e}")
+            logger.error("Error loading model: %s", e)
             return None
 
     def get_base_estimator_input_shape(self):
@@ -86,9 +89,9 @@ class TensorflowModel(ModelInterface):
 
     def sanity_check(self):
         if self.model_state == "pretrained":
-            print("Sanity check for model")
+            logger.info("Sanity check for model")
             input_shape = self.get_base_estimator_input_shape()[1:]  # Omit the batch dimension
-            print("Model input shape is", input_shape)
+            logger.debug("Model input shape is %s", input_shape)
             fake_input = np.random.rand(*input_shape).reshape(1, *input_shape)
             prediction = self.predict(fake_input)
-            print("Sanity check prediction", prediction)
+            logger.debug("Sanity check prediction %s", prediction)

--- a/codice/ceoptimizers/genetic_optimizer.py
+++ b/codice/ceoptimizers/genetic_optimizer.py
@@ -1,8 +1,11 @@
+import logging
 import random
 import numpy as np
 from copy import copy, deepcopy
 from scipy.spatial import distance_matrix
 from scipy.linalg import eigh
+
+logger = logging.getLogger(__name__)
 import scipy.sparse.linalg as spsl
 from codice.ceinstance.instance_sampler import ImmutableSampler, PermittedRangeSampler
 
@@ -512,7 +515,7 @@ class GeneticOptimizer():
         t = 1e-4
         stop_count = 0
         self.population = self.generate_population(query_instance, population_size)
-        print("Get values of one population item", self.population[0].get_values_dict())
+        logger.debug("Get values of one population item %s", self.population[0].get_values_dict())
         fitness_list, loss, distance_combined = self.evaluate_population(self.population, query_instance, desired_output)
         
         # Sorting didn't work properly

--- a/codice/ceutils/diffusion.py
+++ b/codice/ceutils/diffusion.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
 import scipy.sparse as sps
@@ -8,6 +9,8 @@ except ModuleNotFoundError:
     from scipy.misc import logsumexp
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 from sklearn.neighbors import NearestNeighbors
 import scipy.sparse as sps
 import scipy.sparse.linalg as spsl
@@ -38,7 +41,7 @@ class STDiffusionMap(object):
 
     def _make_diffusion_coords(self, L):
         if len(self.data) > 1000:
-            print("The data is too large")
+            logger.warning("The data is too large")
             evals, evecs = spsl.eigsh(L, k=50, which='LM')
         else:
             evals, evecs = spsl.eigs(L, k=((len(self.data) - 1)//2), which='LR')

--- a/codice/cfsearch.py
+++ b/codice/cfsearch.py
@@ -1,8 +1,11 @@
+import logging
 import numpy as np
 import copy
 import os
 import json
 from codice.ceoptimizers.optimizer_interface import OptimizerInterface, OptimizerFactory
+
+logger = logging.getLogger(__name__)
 
 
 class CFsearch:
@@ -51,7 +54,7 @@ class CFsearch:
             filename = indexname + "_" + str(i) + ".json"
             json_path = os.path.join(output_folder, filename)
             # Store counterfactuals in json file
-            print("Store counterfactuals to ", json_path)
+            logger.info("Store counterfactuals to %s", json_path)
             with open(json_path, 'w') as file:
                 counterfactual_values = self.counterfactual_instances[i].get_values_dict()
                 json.dump(counterfactual_values, file, indent=4, default=self.default_serializer)
@@ -69,7 +72,7 @@ class CFsearch:
             filename = indexname + "_eval_" + str(i) + ".json"
             json_path = os.path.join(output_folder, filename)
             # Store counterfactuals in json file
-            print("Store counterfactuals evaluation to ", json_path)
+            logger.info("Store counterfactuals evaluation to %s", json_path)
             with open(json_path, 'w') as file:
                 json.dump(self.evaluations[i], file, indent=4, default=self.default_serializer)
         #TODO
@@ -113,9 +116,9 @@ class CFsearch:
         for cf in self.counterfactual_instances:
             self.store_outcome(cf)
             if self.check_validity(cf):
-                print("Valid counterfactuals were found: ", cf.get_values_dict())
+                logger.info("Valid counterfactual found: %s", cf.get_values_dict())
             else:
-                print("Not all conterfactuals are valid, but the closest instances reported")
+                logger.warning("Counterfactual not valid; reporting closest instance")
         return self.counterfactual_instances
         '''
         # Rounding
@@ -171,7 +174,7 @@ class CFsearch:
         self.original_instance_prediciton = self.model.predict_instance(original_instance)
         self.counterfactual_instances = counterfactual_instances
         if self.counterfactual_instances == []:
-            print("No counterfactuals found, nothing to evaluate.")
+            logger.warning("No counterfactuals found, nothing to evaluate.")
             return
         for i, counterfactual_instance in enumerate(self.counterfactual_instances):
             if not counterfactual_instance.normalized:
@@ -182,13 +185,17 @@ class CFsearch:
             sparsity_cat = self.sparsity_categorical(original_instance, counterfactual_instance)
             validity = self.check_validity(counterfactual_instance)
             coherence_score, incoherent_features = self.check_coherence(original_instance, counterfactual_instance)
-            print("CF instance: ", counterfactual_instance.get_values_dict())
-            print("Distance continuous: ", distance_continuous)
-            print("Distance categorical: ", distance_categorical)
-            print("Sparsity continuous: ", sparsity_cont)
-            print("Sparsity categorical: ", sparsity_cat)
-            print("Validity: ", validity)
-            print("Coherence: ", coherence_score, " incoherent features are ", incoherent_features)
+            logger.debug("CF instance: %s", counterfactual_instance.get_values_dict())
+            logger.debug("Distance continuous: %s", distance_continuous)
+            logger.debug("Distance categorical: %s", distance_categorical)
+            logger.debug("Sparsity continuous: %s", sparsity_cont)
+            logger.debug("Sparsity categorical: %s", sparsity_cat)
+            logger.debug("Validity: %s", validity)
+            logger.debug(
+                "Coherence: %s incoherent features: %s",
+                coherence_score,
+                incoherent_features,
+            )
             self.evaluations.append({"distance_continuous": distance_continuous, 
                                      "distance_categorical": distance_categorical, 
                                      "sparsity_cont": sparsity_cont, 
@@ -331,14 +338,14 @@ class CFsearch:
         # Compare marginal and joint signs and print which are different
         common_keys_same_value, common_keys_diff_value = self.compare_common_keys(marginal_signs, joint_signs)
         if common_keys_same_value:
-            print("Common keys with the same value:", common_keys_same_value)
+            logger.debug("Common keys with the same value: %s", common_keys_same_value)
         else:
-            print("No common keys with the same value found.")
+            logger.debug("No common keys with the same value found.")
 
         if common_keys_diff_value:
-            print("Common keys with different values:", common_keys_diff_value)
+            logger.debug("Common keys with different values: %s", common_keys_diff_value)
         else:
-            print("No common keys with different values found.")
+            logger.debug("No common keys with different values found.")
         
         return
     
@@ -359,7 +366,12 @@ class CFsearch:
         control_instance = copy.deepcopy(original_instance)
         original_instance_value = original_instance.features[feature_name].value
         counterfactual_instance_value = counterfactual_instance.features[feature_name].value
-        print("Feature {} changed its value from {} to {}".format(feature_name, original_instance.features[feature_name].value, counterfactual_instance.features[feature_name].value))
+        logger.debug(
+            "Feature %s changed its value from %s to %s",
+            feature_name,
+            original_instance.features[feature_name].value,
+            counterfactual_instance.features[feature_name].value,
+        )
         # Current prediction of original instance
         # Let's change only counterfactual value of the feature
         control_instance.features[feature_name].value = counterfactual_instance_value
@@ -392,7 +404,12 @@ class CFsearch:
         control_instance = copy.deepcopy(original_instance)
         original_instance_value = original_instance.features[feature_name].value
         counterfactual_instance_value = counterfactual_instance.features[feature_name].value
-        print("Feature {} changed its value from {} to {}".format(feature_name, original_instance.features[feature_name].value, counterfactual_instance.features[feature_name].value))
+        logger.debug(
+            "Feature %s changed its value from %s to %s",
+            feature_name,
+            original_instance.features[feature_name].value,
+            counterfactual_instance.features[feature_name].value,
+        )
         # Current prediction of original instance
         original_prediction = self.model.predict_proba_instance(original_instance)
         # Let's change only counterfactual value of the feature
@@ -447,7 +464,7 @@ class CFsearch:
         import pandas as pd
 
         # original instance
-        print('Query instance (original outcome : %i)' % self.original_instance_prediciton)
+        logger.info('Query instance (original outcome : %i)', self.original_instance_prediciton)
         #if self.query_instance.normalized:
         #    self.transformer.denormalize_instance(self.query_instance)
         display(pd.DataFrame([self.query_instance.get_values_dict()]))  # works only in Jupyter notebook
@@ -456,11 +473,11 @@ class CFsearch:
         
     def _visualize_internal(self, target_instance, counterfactuals, show_only_changes=True, is_notebook_console=False):
         if counterfactuals is not None and len(counterfactuals) > 0:
-            print('\nCounterfactual set (new outcome: {0})'.format(self.new_outcome)) # if more than 1 cf won't work
+            logger.info('\nCounterfactual set (new outcome: %s)', self.new_outcome)
             self._dump_output(content=counterfactuals, show_only_changes=show_only_changes,
                                 is_notebook_console=is_notebook_console)
         else:
-            print('\nNo counterfactuals found!')
+            logger.info('\nNo counterfactuals found!')
 
     def _dump_output(self, content, show_only_changes=True, is_notebook_console=False):
         import pandas as pd
@@ -474,7 +491,7 @@ class CFsearch:
     def print_list(self, li, show_only_changes):
         if show_only_changes is False:
             for ix in range(len(li)):
-                print(li[ix])
+                logger.info(li[ix])
         else:
             newli = copy.deepcopy(li)
             org = self.test_instance_df.values.tolist()[0]
@@ -482,7 +499,7 @@ class CFsearch:
                 for jx in range(len(newli[ix])):
                     if newli[ix][jx] == org[jx]:
                         newli[ix][jx] = '-'
-                print(newli[ix])
+                logger.info(newli[ix])
 
     def display_df(self, df, show_only_changes):
         from IPython.display import display

--- a/codice/dataset.py
+++ b/codice/dataset.py
@@ -1,7 +1,10 @@
+import logging
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from codice.ceinstance import CEInstance
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 class Dataset(object):
     """
@@ -11,11 +14,17 @@ class Dataset(object):
         self.config = config
         self.path = self.config["path"]
         self.outcome_column_name = outcome_column_name
+        logger.info("Loading dataset from %s", self.path)
         self.data = self.load_dataset()
         # Initialize lists to ensure they exist even if not defined in config
         self.continuous_features_list = []
         self.categorical_features_list = []
-        self.continuous_features_list, self.categorical_features_list = self.load_features_type() # test empty  
+        self.continuous_features_list, self.categorical_features_list = self.load_features_type() # test empty
+        logger.info(
+            "Loaded %d continuous and %d categorical features",
+            len(self.continuous_features_list),
+            len(self.categorical_features_list),
+        )
 
         self.verify_features()
         self.preprocess_dataset()
@@ -42,7 +51,7 @@ class Dataset(object):
             continuous_features = self.config['continuous_features']
             categorical_features = self.config['categorical_features']
         except KeyError:
-            print("No features type found in config file")
+            logger.warning("No features type found in config file")
             continuous_features, categorical_features = self.infer_feature_type_from_dataset()
         return continuous_features, categorical_features
 
@@ -86,14 +95,15 @@ class Dataset(object):
         for feature_name in self.config['categorical_features']:
             self.check_if_categorical(feature_name)
 
-        print("Features verified")
-        print("Continious features: {}".format(self.continuous_features_list))
-        print("Categorical features: {}".format(self.categorical_features_list))
+        logger.info("Features verified")
+        logger.debug("Continuous features: %s", self.continuous_features_list)
+        logger.debug("Categorical features: %s", self.categorical_features_list)
 
     def preprocess_dataset(self):
         """
         Preprocess dataset
         """
+        logger.info("Preprocessing dataset")
         if self.outcome_column_name == "Loan_Status":
             self.data.loc[self.data["Loan_Status"]=="Y", "Loan_Status"] = 1
             self.data.loc[self.data["Loan_Status"]=="N", "Loan_Status"] = 0
@@ -121,7 +131,7 @@ class Dataset(object):
 
         self.data = self.data.reset_index(drop=True)
 
-        print("Dataset preprocessed")
+        logger.info("Dataset preprocessed")
 
 
     def split_dataset(self, outcome_column_name):
@@ -132,6 +142,12 @@ class Dataset(object):
 
         x_train, x_val, y_train, y_val = train_test_split(
             X, y, test_size=0.2, random_state=1
+        )
+
+        logger.info(
+            "Dataset split into %d training and %d validation instances",
+            len(x_train),
+            len(x_val),
         )
 
         return x_train, x_val, y_train, y_val

--- a/codice/feature_manager.py
+++ b/codice/feature_manager.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import numpy as np
 import logging
+
+logger = logging.getLogger(__name__)
 import sklearn
 from typing import List, Union
 from dataset import Dataset
@@ -131,18 +133,18 @@ class FeatureManager(object):
         self.cov1 = np.cov(self.normalized_train_data.loc[self.training_data[self.outcome_name]==1].values.T, bias=True)
         try:
             self.inv_cov_cl1 = np.linalg.inv(self.cov1)
-            print("Matrix for class 1 is non-singular")
+            logger.debug("Matrix for class 1 is non-singular")
         except np.linalg.LinAlgError:
-            print("Matrix is singular")
+            logger.warning("Matrix is singular")
             self.inv_cov_cl1 = False
 
         self.mean_out0 = self.normalized_train_data.loc[self.training_data[self.outcome_name]==0, self.continuous_features_list].mean()
         self.cov0 = np.cov(self.normalized_train_data.loc[self.training_data[self.outcome_name]==0].values.T, bias=True)
         try:
             self.inv_cov_cl0 = np.linalg.inv(self.cov0)
-            print("Matrix is non-singular")
+            logger.debug("Matrix is non-singular")
         except np.linalg.LinAlgError:
-            print("Matrix is singular")
+            logger.warning("Matrix is singular")
             self.inv_cov_cl0 = False
 
     def get_mads(self, normalized=True):

--- a/codice/logging_utils.py
+++ b/codice/logging_utils.py
@@ -1,0 +1,15 @@
+import logging
+
+
+def setup_logging(level=logging.INFO):
+    """Configure root logger to output to the console."""
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+        handler.setFormatter(formatter)
+        root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+

--- a/codice/train.py
+++ b/codice/train.py
@@ -1,3 +1,4 @@
+import logging
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.compose import ColumnTransformer
@@ -8,6 +9,8 @@ import os
 from sklearn.model_selection import train_test_split
 import pandas as pd
 from codice.cemodels.explainable_model import ExplainableModel
+
+logger = logging.getLogger(__name__)
 
 def load_dataset(confpath, datasetpath):
     # Read the configuration file
@@ -27,7 +30,7 @@ def load_dataset(confpath, datasetpath):
                 # Add parameter name and value to dictionary
                 config_dict[parameter_name.strip()] = parameter_value.strip()
 
-    print(config_dict)
+    logger.debug(config_dict)
 
     train = pd.read_csv(datasetpath)
     continuous_features_list = ['ApplicantIncome','CoapplicantIncome','LoanAmount', 'Loan_Amount_Term']
@@ -76,7 +79,7 @@ def train_model(transformations, x_train, x_val, y_train, y_val):
     logistic_model = model.fit(x_train, y_train.values.ravel())
     y_pred = logistic_model.predict(x_val)
     val_accuracy = accuracy_score(y_pred, y_val)*100
-    print(val_accuracy)
+    logger.info("Validation accuracy: %s", val_accuracy)
 
     return logistic_model
 

--- a/codice/transformer.py
+++ b/codice/transformer.py
@@ -1,8 +1,11 @@
+import logging
 import numpy as np
 from scipy.spatial import distance_matrix
 from scipy.linalg import eigh
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.preprocessing import LabelEncoder
+
+logger = logging.getLogger(__name__)
 from codice.ceutils.diffusion import STDiffusionMap
 
 class Transformer(object):
@@ -156,7 +159,7 @@ class Transformer(object):
             if mads[feature] <= 0:
                 mads[feature] = 1.0
                 #if display_warnings:
-                print(" MAD for feature %s is 0, so replacing it with 1.0 to avoid error.", feature)
+                logger.warning("MAD for feature %s is 0, replaced with 1.0 to avoid error.", feature)
         return mads
 
 
@@ -317,7 +320,12 @@ class FeatureTransformer(object):
     
     def _label_enc(self, value):
         transformed_value = self.label_encoder.transform([value])[0]
-        print("Label encoder: ", value, " for feature ", self.feature_name, " is transformed into ", transformed_value)
+        logger.debug(
+            "Label encoder: %s for feature %s is transformed into %s",
+            value,
+            self.feature_name,
+            transformed_value,
+        )
         return transformed_value
     
     def _label_dec(self, value):


### PR DESCRIPTION
## Summary
- introduce `logging_utils.setup_logging` and enable it in `__init__`
- convert print statements to logging calls in major modules
- log key steps when loading datasets, searching counterfactuals and training models